### PR TITLE
Configure GitHub Action to publish from GitHub to Terra.

### DIFF
--- a/.github/workflows/publish-to-terra.yml
+++ b/.github/workflows/publish-to-terra.yml
@@ -1,9 +1,13 @@
 name: Publish to Terra
+# Publish notebooks and dashboard markdown from the source-of-truth, a GitHub repository, to the
+# deployment destination, a Terra workspace. See http://app.terra.bio for more detail.
+#
+# Only use this workflow for Terra workspaces that are simply mirrors of GitHub repositories, as
+# it overwrites assets in Terra-managed storage.
 
 on:
   workflow_dispatch:
-    # Allows manually triggering workflow in GitHub UI on selected branch.
-    # GitHub doc: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#workflow_dispatch.
+    # Allows manually triggering of workflow on a selected branch via the GitHub Actions tab.
     # GitHub blog demo: https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/.
 
   push:
@@ -12,6 +16,7 @@ on:
       - v*
 
 env:
+  # TO REUSE THIS TEMPLATE, change these values to reflect those of your destination Terra workspace.
   NAMESPACE: 'fc-product-demo'
   WORKSPACE: 'github-action-deploy-to-terra'
   WORKSPACE_BUCKET: 'fc-33f00650-4555-4140-a4ea-9014f85c58e7'
@@ -32,7 +37,13 @@ jobs:
 
     - name: Setup gcloud CLI
       uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+      # TO REUSE THIS TEMPLATE, configure auth.
+      # Step 1: Create a service account and store its key in GitHub secrets per these instructions:
       # https://github.com/google-github-actions/setup-gcloud/blob/master/setup-gcloud/README.md
+      # Step 2: Register the service account with Terra per these instructions
+      # https://github.com/broadinstitute/terra-tools/tree/master/scripts/register_service_account
+      # Step 3: Share the destination Terra workspace with the service account, granting it
+      # "WRITER" access.
       with:
         version: '290.0.1'
         service_account_key: ${{ secrets.TERRA_SECRET }}
@@ -40,22 +51,23 @@ jobs:
 
     - name: Publish dashboard and notebooks
       run: |
-        cd terra-notebooks-playground/
-
         # Install the Terra client.
         pip install firecloud==0.16.25
 
-        # Publish notebooks
+        # Change to the directory holding the workspace assets.
+        # TO REUSE THIS TEMPLATE, upate the code to match your directory structure.
+        # This particular example is based on the structure of https://github.com/DataBiosphere/notebooks
+        cd terra-notebooks-playground/
+
+        # Publish the notebooks.
         gsutil -m cp *.ipynb "gs://${WORKSPACE_BUCKET}/notebooks/"
 
-        # Publish dashboard markdown
+        # Publish the dashboard markdown.
         python << EOF
-
         import firecloud.api as fapi
         with open('README.md') as f:
           fapi.update_workspace_attributes(
               namespace="$NAMESPACE",
               workspace="$WORKSPACE",
               attrs=[fapi._attr_set(attr='description', value=f.read())]).json()
-
         EOF

--- a/.github/workflows/publish-to-terra.yml
+++ b/.github/workflows/publish-to-terra.yml
@@ -15,9 +15,9 @@ on:
 
 env:
   # TO REUSE THIS TEMPLATE, change these values to reflect those of your destination Terra workspace.
-  NAMESPACE: 'fc-product-demo'
-  WORKSPACE: 'github-action-deploy-to-terra'
-  WORKSPACE_BUCKET: 'fc-33f00650-4555-4140-a4ea-9014f85c58e7'
+  NAMESPACE: 'help-gatk'
+  WORKSPACE: 'Terra Notebooks Playground'
+  WORKSPACE_BUCKET: 'fc-6aca927c-4f84-4c72-b0a4-03819cce9a9d'
 
 jobs:
 

--- a/.github/workflows/publish-to-terra.yml
+++ b/.github/workflows/publish-to-terra.yml
@@ -15,6 +15,10 @@ on:
     tags:
       - v*
 
+    TODO(deflaux) remove this after testing is complete.
+    branches: [ terra-publish ]
+
+
 env:
   # TO REUSE THIS TEMPLATE, change these values to reflect those of your destination Terra workspace.
   NAMESPACE: 'fc-product-demo'
@@ -23,7 +27,7 @@ env:
 
 jobs:
 
-  push:
+  deploy_to_terra:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/publish-to-terra.yml
+++ b/.github/workflows/publish-to-terra.yml
@@ -10,14 +10,8 @@ on:
     # Allows manually triggering of workflow on a selected branch via the GitHub Actions tab.
     # GitHub blog demo: https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/.
 
-  push:
-    # Publish `v1.2.3` tags as releases.
-    tags:
-      - v*
-
-    # TODO(deflaux) remove this after testing is complete.
-    branches: [ terra-publish ]
-
+  release:
+    types: [published]
 
 env:
   # TO REUSE THIS TEMPLATE, change these values to reflect those of your destination Terra workspace.

--- a/.github/workflows/publish-to-terra.yml
+++ b/.github/workflows/publish-to-terra.yml
@@ -1,0 +1,61 @@
+name: Publish to Terra
+
+on:
+  workflow_dispatch:
+    # Allows manually triggering workflow in GitHub UI on selected branch.
+    # GitHub doc: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows#workflow_dispatch.
+    # GitHub blog demo: https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/.
+
+  push:
+    # Publish `v1.2.3` tags as releases.
+    tags:
+      - v*
+
+env:
+  NAMESPACE: 'fc-product-demo'
+  WORKSPACE: 'github-action-deploy-to-terra'
+  WORKSPACE_BUCKET: 'fc-33f00650-4555-4140-a4ea-9014f85c58e7'
+
+jobs:
+
+  push:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+
+    - name: Setup gcloud CLI
+      uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+      # https://github.com/google-github-actions/setup-gcloud/blob/master/setup-gcloud/README.md
+      with:
+        version: '290.0.1'
+        service_account_key: ${{ secrets.TERRA_SECRET }}
+        export_default_credentials: true
+
+    - name: Publish dashboard and notebooks
+      run: |
+        cd terra-notebooks-playground/
+
+        # Install the Terra client.
+        pip install firecloud==0.16.25
+
+        # Publish notebooks
+        gsutil -m cp *.ipynb "gs://${WORKSPACE_BUCKET}/notebooks/"
+
+        # Publish dashboard markdown
+        python << EOF
+
+        import firecloud.api as fapi
+        with open('README.md') as f:
+          fapi.update_workspace_attributes(
+              namespace="$NAMESPACE",
+              workspace="$WORKSPACE",
+              attrs=[fapi._attr_set(attr='description', value=f.read())]).json()
+
+        EOF

--- a/.github/workflows/publish-to-terra.yml
+++ b/.github/workflows/publish-to-terra.yml
@@ -15,7 +15,7 @@ on:
     tags:
       - v*
 
-    TODO(deflaux) remove this after testing is complete.
+    # TODO(deflaux) remove this after testing is complete.
     branches: [ terra-publish ]
 
 

--- a/.github/workflows/publish-to-terra.yml
+++ b/.github/workflows/publish-to-terra.yml
@@ -58,9 +58,10 @@ jobs:
         # Install the Terra client.
         pip install firecloud==0.16.25
 
-        # Change to the directory holding the workspace assets.
-        # TO REUSE THIS TEMPLATE, upate the code to match your directory structure.
+        # TO REUSE THIS TEMPLATE, upate the code to match your file and directory structure.
         # This particular example is based on the structure of https://github.com/DataBiosphere/notebooks
+
+        # Change to the directory holding the workspace assets.
         cd terra-notebooks-playground/
 
         # Publish the notebooks.

--- a/.github/workflows/publish-to-terra.yml
+++ b/.github/workflows/publish-to-terra.yml
@@ -38,6 +38,7 @@ jobs:
       # TO REUSE THIS TEMPLATE, configure auth.
       # Step 1: Create a service account and store its key in GitHub as 'TERRA_SECRET' per these instructions:
       # https://github.com/google-github-actions/setup-gcloud/blob/master/setup-gcloud/README.md
+      # https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository
       # Step 2: Register the service account with Terra per these instructions
       # https://github.com/broadinstitute/terra-tools/tree/master/scripts/register_service_account
       # Step 3: Share the destination Terra workspace with the service account, granting it

--- a/.github/workflows/publish-to-terra.yml
+++ b/.github/workflows/publish-to-terra.yml
@@ -40,9 +40,9 @@ jobs:
         python-version: 3.7
 
     - name: Setup gcloud CLI
-      uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@master
       # TO REUSE THIS TEMPLATE, configure auth.
-      # Step 1: Create a service account and store its key in GitHub secrets per these instructions:
+      # Step 1: Create a service account and store its key in GitHub as 'TERRA_SECRET' per these instructions:
       # https://github.com/google-github-actions/setup-gcloud/blob/master/setup-gcloud/README.md
       # Step 2: Register the service account with Terra per these instructions
       # https://github.com/broadinstitute/terra-tools/tree/master/scripts/register_service_account

--- a/terra-notebooks-playground/README.md
+++ b/terra-notebooks-playground/README.md
@@ -84,3 +84,15 @@ If you are developing R packages:
 * [ggplot2 cheatsheet](https://www.rstudio.com/resources/cheatsheets/#ggplot2) 
 * [R Graph Gallery](https://www.r-graph-gallery.com/) inspiration and help with R Graphics
 * [This is the most important tip of all ;-)](https://flowingdata.com/2012/06/07/always-label-your-axes/)
+
+---
+
+### Contact information
+
+In addition to Terra support, you can also reach us on GitHub by [filing an issue](https://github.com/DataBiosphere/notebooks/issues).
+
+### License
+Please see the BSD-3-Clause [license on GitHub](https://github.com/DataBiosphere/notebooks/blob/master/LICENSE.md)
+
+### Workspace Change Log
+Please see the [pull request history](https://github.com/DataBiosphere/notebooks/pulls?q=is%3Apr+) on GitHub.


### PR DESCRIPTION
This GitHub action will publish workspace dashboard markdown and notebooks to the target Terra workspace when either (1) a release is created or (2) the workflow is invoked manually using the GitHub Actions user interface.

For test purposes, it currently deploys to here: https://app.terra.bio/#workspaces/fc-product-demo/github-action-deploy-to-terra

To instead have it deploy to featured workspace https://app.terra.bio/#workspaces/help-gatk/Terra%20Notebooks%20Playground , follow the instructions within the workflow file to set up the credential in GitHub and update the environment variables to point to that workspace and its bucket.