### PR TITLE
remove a cell that contained hardwired project info

### DIFF
--- a/terra-notebooks-playground/Py3 - How to store analysis results in BigQuery and Cloud Storage.ipynb
+++ b/terra-notebooks-playground/Py3 - How to store analysis results in BigQuery and Cloud Storage.ipynb
@@ -73,17 +73,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 4,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "PROJECT_ID = 'ah-native-gcp-project-74939'\n",
-    "BUCKET = 'gs://ah-native-gcp-project-74939-autodelete-after-one-day'\n",
-    "BQ_DATASET = 'BQ_dataset_autodelete_after_one_day'"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {
     "heading_collapsed": true


### PR DESCRIPTION
This notebook had a cell with hardwired project info, which I assume was not intended (especially since it would overwrite the user's own info in the previous cell). 