### PR TITLE
Update publish-to-terra.yml

### DIFF
--- a/.github/workflows/publish-to-terra.yml
+++ b/.github/workflows/publish-to-terra.yml
@@ -34,7 +34,7 @@ jobs:
         python-version: 3.7
 
     - name: Setup gcloud CLI
-      uses: google-github-actions/setup-gcloud@master
+      uses: google-github-actions/setup-gcloud@v0
       # TO REUSE THIS TEMPLATE, configure auth.
       # Step 1: Create a service account and store its key in GitHub as 'TERRA_SECRET' per these instructions:
       # https://github.com/google-github-actions/setup-gcloud/blob/master/setup-gcloud/README.md


### PR DESCRIPTION
deploy-to-terra action throws an [error](https://github.com/DataBiosphere/terra-example-notebooks/actions/runs/2054166993):

```
On 2022-04-05, the default branch will be renamed from "master" to "main". Your action is currently pinned to "@master". Even though GitHub creates redirects for renamed branches, testing found that this rename breaks existing GitHub Actions workflows that are pinned to the old branch name.

We strongly advise updating your GitHub Action YAML from:

    uses: 'google-github-actions/setup-gcloud@master'

to:

    uses: 'google-github-actions/setup-gcloud@v0'

While not recommended, you can still pin to the "master" branch by setting the environment variable "SETUP_GCLOUD_I_UNDERSTAND_USING_MASTER_WILL_BREAK_MY_WORKFLOW_ON_2022_04_05=1". However, on 2022-04-05 when the branch is renamed, all your workflows will begin failing with an obtuse and difficult to diagnose error message.

For more information, please see: https://github.com/google-github-actions/setup-gcloud/issues/539
```

This is tracked by a GitHub [issue](https://github.com/google-github-actions/setup-gcloud/issues/539).