### PR TITLE
Only manual dispatch for 'Publish to Terra' GitHub action

### DIFF
--- a/.github/workflows/publish-to-terra.yml
+++ b/.github/workflows/publish-to-terra.yml
@@ -10,9 +10,6 @@ on:
     # Allows manually triggering of workflow on a selected branch via the GitHub Actions tab.
     # GitHub blog demo: https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/.
 
-  release:
-    types: [published]
-
 env:
   # TO REUSE THIS TEMPLATE, change these values to reflect those of your destination Terra workspace.
   NAMESPACE: 'help-gatk'


### PR DESCRIPTION
Now that we no longer store outputs in the notebooks in source control, this GitHub action needs to be revisited. For now, just disable any automatic invocation of it.